### PR TITLE
Specify typescript version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 	"devDependencies": {
 		"@types/jest": "^29.5.14",
 		"@types/node": "^18.19.67",
-		"jest": "^29.7.0"
+		"jest": "^29.7.0",
+		"typescript": "^5.6.3"
 	},
 	"dependencies": {
 		"@sapphire/snowflake": "^3.5.5",


### PR DESCRIPTION
To ensure we're all using the same version of typescript, I've added it to the package.json dev dependencies.