### PR TITLE
Updated tests for sortPrimitive.test.js

### DIFF
--- a/test/array/sort/sortPrimitive.test.js
+++ b/test/array/sort/sortPrimitive.test.js
@@ -1,0 +1,73 @@
+import { sortPrimitive } from "../../../build/index.js";
+
+describe("array", () => {
+	describe("sort", () => {
+		describe("sortPrimitive", () => {
+			const _input = [ 2,1,null,"2",true,null,undefined,2,null,"1",1,false,true];
+			const _input_dates = [ 283334400001,new Date(1978, 11, 24),283334400000,new Date(1978, 11, 24)];
+			const _input_mixed = _input.concat(_input_dates);
+
+			test(`sortPrimitive`, () => {
+				const input = _input.slice();
+				const expected = [false,true,true,1,1,"1",2,2,"2",null,null,null,undefined];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive);
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive() (reversed)`, () => {
+				const input = _input.slice();
+				const expected = [ undefined,null,null,null,"2",2,2,"1",1,1,true,true,false];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive).reverse();
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (dates)`, () => {
+				const input = _input_dates;
+				const expected = [ new Date(1978, 11, 24),new Date(1978, 11, 24),283334400000,283334400001];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive);
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (reversed dates)`, () => {
+				const input = _input_dates;
+				const expected = [ 283334400001,283334400000,new Date(1978, 11, 24),new Date(1978, 11, 24) ];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive).reverse();
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (mixed)`, () => {
+				const input = _input_mixed;
+				const expected = [ false,true,true,1,1,"1",2,2,"2",new Date(1978, 11, 24),new Date(1978, 11, 24),283334400000,283334400001,null,null,null,undefined ];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive);
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (reversed mixed)`, () => {
+				const input = _input_mixed;
+				const expected = [ undefined,null,null,null,283334400001,283334400000,new Date(1978, 11, 24),new Date(1978, 11, 24),"2",2,2,"1",1,1,true,true,false ];
+				expect(input).not.toStrictEqual(expected);
+				input.sort(sortPrimitive).reverse();
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (single value)`, () => {
+				const input = [ false ];
+				const expected = [ false ];
+				input.sort(sortPrimitive).reverse();
+				expect(input).toStrictEqual(expected);
+			});
+
+			test(`sortPrimitive (empty array)`, () => {
+				const input = [];
+				const expected = [];
+				input.sort(sortPrimitive).reverse();
+				expect(input).toStrictEqual(expected);
+			});
+		});
+	});
+});

--- a/test/array/sorters.test.js
+++ b/test/array/sorters.test.js
@@ -2,46 +2,21 @@ import { or, sortAsPrimitive, sortPrimitive } from "../../build/index.js";
 
 describe("array", () => {
 	describe("sorters", () => {
-
-		const _input = [2,1,null,"2",true,null,undefined,2,null,"1",1,false,true];
-
-		test(`sortPrimitive`, () => {
-			const input = _input.slice();
-			const expected = [false,true,true,1,1,"1",2,2,"2",null,null,null,undefined];
-			expect(input).not.toStrictEqual(expected);
-			input.sort(sortPrimitive);
-			expect(input).toStrictEqual(expected);
-		});
-
-		test(`sortPrimitive() (reversed)`, () => {
-			const input = _input.slice();
-			const expected = [undefined,null,null,null,"2",2,2,"1",1,1,true,true,false];
-			expect(input).not.toStrictEqual(expected);
-			input.sort(sortPrimitive).reverse();
-			expect(input).toStrictEqual(expected);
-		});
+		const _input = [ 2,1,null,"2",true,null,undefined,2,null,"1",1,false,true];
 
 		test(`sortAsPrimitive("string")`, () => {
 			const input = _input.slice();
-			const expected = [1,"1",1,2,"2",2,false,true,true,null,null,null,undefined];
+			const expected = [ 1,"1",1,2,"2",2,false,true,true,null,null,null,undefined];
 			expect(input).not.toStrictEqual(expected);
 			input.sort(sortAsPrimitive("string"));
 			expect(input).toStrictEqual(expected);
 		});
 
-		test(`sortPrimitive (dates)`, () => {
-			const input = [283334400001,new Date(1978,11,24),283334400000,new Date(1978,11,24)];
-			const expected = [new Date(1978,11,24),283334400000,new Date(1978,11,24),283334400001];
-			expect(input).not.toStrictEqual(expected);
-			input.sort(sortPrimitive);
-			expect(input).toStrictEqual(expected);
-		});
-
 		test(`or((a,b)=>sortPrimitive(a.level,b.level),(a,b)=>sortPrimitive(a.name,b.name))`, () => {
 			const input = [{level:0,name:"Zero"},{level:1,name:"Zero"},{level:0,name:"zero"},{level:0,name:"one"},{level:1,name:"zero"},{level:1,name:"one"}];
-			const expected = [{ level: 0, name: "one" },{ level: 0, name: "Zero" },{ level: 0, name: "zero" },{ level: 1, name: "one" },{ level: 1, name: "Zero" },{ level: 1, name: "zero" }];
+			const expected = [{level:0,name:"one"},{level:0,name:"Zero"},{level:0,name:"zero"},{level:1,name:"one"},{level:1,name:"Zero"},{level:1,name:"zero"}];
 			expect(input).not.toStrictEqual(expected);
-			input.sort(or((a,b)=>sortPrimitive(a.level,b.level),(a,b)=>sortPrimitive(a.name,b.name)));
+			input.sort(or((a, b) => sortPrimitive(a.level, b.level),(a, b) => sortPrimitive(a.name, b.name)));
 			expect(input).toStrictEqual(expected);
 		});
 	});


### PR DESCRIPTION
Fixed the date test for sortPrimitive (date) and added a few other tests to try and cover the edge cases: mixed dates and other input, single values, and empty arrays.

Moved all the tests to test/array/sort/sortPrimitive.test.js.

A very small pull request to verify standards and get me that dopamine hit of having accomplished something >.>